### PR TITLE
Build passwords as a SecureString.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # PSPasswordGenerator change log
 
 ## Version 3.1.0 (in development)
-Packaging improvements.
+- This version is more secure, as the generated password is now built in memory as a `[SecureString]`, and only converted from one when this cmdlet is run with `-AsPlainText`.
+- Packaging improvements.
 
 ## Version 3.0.0 (March 17, 2022)
 - We can now generate human-friendly passwords from wordlists.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # PSPasswordGenerator
 History of user-visible changes.
-Last update: 2024-01-31
+Last update: 2024-02-01
 
 ## PSPasswordGenerator version 3.0.1, in development
-Packaging improvements.
+This version builds the password in-memory as a `[SecureString]`, which means it is never stored insecurely.
 
 ## PSPasswordGenerator version 3.0.0, released 3/17/2022
 Not dead yet!  In this version, the cmdlet's verb has been changed.  It is now called `Get-RandomPassword` (but `New-RandomPassword` still works.)

--- a/PSPasswordGenerator.psd1
+++ b/PSPasswordGenerator.psd1
@@ -22,7 +22,7 @@
 RootModule = 'src/PSPasswordGenerator.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0.1'
+ModuleVersion = '3.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -91,7 +91,8 @@ PrivateData = @{
 		IconUri = 'https://raw.githubusercontent.com/rhymeswithmogul/PSPasswordGenerator/main/icon/PSPasswordGenerator.png'
 
 		# ReleaseNotes of this module
-		ReleaseNotes = 'Packaging improvements.'
+		ReleaseNotes = '- Strings are now generated securely on supported platforms.
+- Packaging improvements.'
 
 		# Flag to indicate whether the module requires explicit user acceptance for install/update/save
 		RequireLicenseAcceptance = $false


### PR DESCRIPTION
This commit was going to fix a PSScriptAnalyzer error by disabling that rule, but I couldn't do that.  Instead, I changed the behavior of this module so that passwords are now built as SecureStrings and converted to plaintext at the end, rather than the other way around.